### PR TITLE
fix: name of smb app template on document service

### DIFF
--- a/change-logs/smb-onboarder.md
+++ b/change-logs/smb-onboarder.md
@@ -5,5 +5,5 @@ description: >-
   features/enhancements that have been added.
 ---
 
-# SMB
+# SMB Onboarder
 


### PR DESCRIPTION
Changes
- Name of smb app to smb-onboarder